### PR TITLE
fix(BUILD-1287): repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sonarsource/infra-team
+* @sonarsource/helpdesk-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sonarsource/infra-team


### PR DESCRIPTION
Set the team @SonarSource/infra-team as code owner in `.github/CODEOWNERS` file.

This is required by [BUILD-1271](https://jira.sonarsource.com/browse/BUILD-1271).
Contact @SonarSource/re-team for more information.
